### PR TITLE
Issue/#31/ForeignKeyReferenceIssue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ $tf/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
+*.DotSettings
 
 # JustCode is a .NET coding addin-in
 .JustCode

--- a/src/lhm.net.sample/Program.cs
+++ b/src/lhm.net.sample/Program.cs
@@ -11,7 +11,7 @@ namespace lhm.Test
     {
         static void Main(string[] args)
         {
-            const string connectionString = "Server=localhost;;Initial Catalog=Lhm.Test;Integrated Security=True";
+            const string connectionString = "Server=(localdb)\\v11.0;;Initial Catalog=Lhm.Test;Integrated Security=True";
 
             Lhm.Setup(connectionString);
 

--- a/src/lhm.net.sample/Program.cs
+++ b/src/lhm.net.sample/Program.cs
@@ -11,7 +11,7 @@ namespace lhm.Test
     {
         static void Main(string[] args)
         {
-            const string connectionString = "Server=(localdb)\\v11.0;;Initial Catalog=Lhm.Test;Integrated Security=True";
+            const string connectionString = "Server=localhost;;Initial Catalog=Lhm.Test;Integrated Security=True";
 
             Lhm.Setup(connectionString);
 

--- a/src/lhm.net.sample/Program.cs
+++ b/src/lhm.net.sample/Program.cs
@@ -11,13 +11,18 @@ namespace lhm.Test
     {
         static void Main(string[] args)
         {
-            const string connectionString = "Server=(localdb)\\v11.0;;Initial Catalog=Lhm.Test;Integrated Security=True";
+            const string connectionString = "Server=localhost;;Initial Catalog=Lhm.Test;Integrated Security=True";
 
             Lhm.Setup(connectionString);
 
             Lhm.CleanUp(true);
 
             SetupSampleDatabase(connectionString);
+
+            Lhm.ChangeTable("Position", migrator =>
+            {
+                migrator.RenameColumn("Name", "Type");
+            });
 
             Lhm.ChangeTable("User", migrator =>
             {
@@ -47,11 +52,6 @@ namespace lhm.Test
             Lhm.ChangeTable("User", migrator =>
             {
                 migrator.RemoveIndex("Email");
-            });
-
-            Lhm.ChangeTable("Position", migrator =>
-            {
-                migrator.RenameColumn("Name", "Type");
             });
 
             Console.ReadLine();

--- a/src/lhm.net/Chunker.cs
+++ b/src/lhm.net/Chunker.cs
@@ -46,7 +46,6 @@ namespace lhm.net
 
             Logger.Info($"Finsihed copying data from: {_migration.Origin.Name} to {_migration.Destination.Name} rows copied:{rowsAffected}");
         }
-
         private int Copy(int skip, int take)
         {
             var identityStatement = $"SET IDENTITY_INSERT [{_migration.Destination.Name}] ON";

--- a/src/lhm.net/Lhm.cs
+++ b/src/lhm.net/Lhm.cs
@@ -63,9 +63,6 @@ namespace lhm.net
 
         public static void CleanUp(bool run = false)
         {
-            var dependantTables = Connection.Query<string>("SELECT DISTINCT b.name FROM sys.foreign_keys a INNER JOIN sys.objects b ON b.object_id = a.parent_object_id")
-                    .ToList();
-
             var tables = Connection.Query<string>("SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_NAME Like '%_lhm_%'")
                 .ToList();
 
@@ -79,12 +76,7 @@ namespace lhm.net
                     _connection.Execute(string.Format("DROP Trigger [{0}]", s));
                 });
                 
-                dependantTables.ForEach(s =>
-                {
-                    _connection.Execute(string.Format("DROP TABLE [{0}]", s));
-                });
-
-                tables.Except(dependantTables).ToList().ForEach(s =>
+                tables.ForEach(s =>
                 {
                     _connection.Execute(string.Format("DROP TABLE [{0}]", s));
                 });

--- a/src/lhm.net/Lhm.cs
+++ b/src/lhm.net/Lhm.cs
@@ -63,6 +63,9 @@ namespace lhm.net
 
         public static void CleanUp(bool run = false)
         {
+            var dependantTables = Connection.Query<string>("SELECT DISTINCT b.name FROM sys.foreign_keys a INNER JOIN sys.objects b ON b.object_id = a.parent_object_id")
+                    .ToList();
+
             var tables = Connection.Query<string>("SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_NAME Like '%_lhm_%'")
                 .ToList();
 
@@ -75,8 +78,13 @@ namespace lhm.net
                 {
                     _connection.Execute(string.Format("DROP Trigger [{0}]", s));
                 });
+                
+                dependantTables.ForEach(s =>
+                {
+                    _connection.Execute(string.Format("DROP TABLE [{0}]", s));
+                });
 
-                tables.ForEach(s =>
+                tables.Except(dependantTables).ToList().ForEach(s =>
                 {
                     _connection.Execute(string.Format("DROP TABLE [{0}]", s));
                 });

--- a/src/lhm.net/lhm.net.csproj.DotSettings
+++ b/src/lhm.net/lhm.net.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=app_005Fpackages/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Caveat: A migration on a table which contains the FK reference value should be executed before the table which contains the foreign key entry.

Updated TravelAgent with a new regex to change the name of the foreign key reference table.
Updated Lhm to drop parent tables before dependant table.
