### PR TITLE
Centralise migration date time stamp logic

### DIFF
--- a/src/lhm.net/Constants.cs
+++ b/src/lhm.net/Constants.cs
@@ -1,7 +1,0 @@
-namespace lhm.net
-{
-    public class Constants
-    {
-        public const string DateTimeStampFormat = "yyyy_MM_dd_hh_mm_ss_fff";
-    }
-}

--- a/src/lhm.net/Entangler.cs
+++ b/src/lhm.net/Entangler.cs
@@ -17,7 +17,7 @@ namespace lhm.net
         private readonly Table _origin;
         private readonly Table _destination;
         private readonly Intersection _intersection;
-        private readonly string _timestamp;
+        private readonly MigrationDateTimeStamp _migrationDateTimeStamp;
 
         public Entangler(TableMigration migration, ILhmConnection connection)
         {
@@ -25,7 +25,7 @@ namespace lhm.net
             _intersection = migration.Intersection;
             _origin = migration.Origin;
             _destination = migration.Destination;
-            _timestamp = migration.DateTimeStamp;
+            _migrationDateTimeStamp = migration.MigrationDateTimeStamp;
         }
 
         public void Run()
@@ -52,7 +52,7 @@ namespace lhm.net
 
         private string CreateInsertTrigger()
         {
-            return $@"CREATE TRIGGER [{_origin.Name}_Insert_lhm_{_timestamp}] ON [{_origin.Name}] 
+            return $@"CREATE TRIGGER [{_origin.Name}_Insert_lhm_{_migrationDateTimeStamp}] ON [{_origin.Name}] 
                         AFTER INSERT 
                         AS 
                         BEGIN 
@@ -67,7 +67,7 @@ namespace lhm.net
                    .Select(info => $"[{_destination.Name}].[{info.DestinationColumns.Name}] = INSERTED.{info.OriginColumns.Name},"))
                    .TrimEnd(',');
 
-            return $@"CREATE TRIGGER [{_origin.Name}_Update_lhm_{_timestamp}] ON [{_origin.Name}] 
+            return $@"CREATE TRIGGER [{_origin.Name}_Update_lhm_{_migrationDateTimeStamp}] ON [{_origin.Name}] 
                         AFTER Update 
                         AS 
                         BEGIN 
@@ -80,7 +80,7 @@ namespace lhm.net
 
         private string CreateDeleteTrigger()
         {
-            return $@"CREATE TRIGGER [{_origin.Name}_Delete_lhm_{_timestamp}] ON [{_origin.Name}] 
+            return $@"CREATE TRIGGER [{_origin.Name}_Delete_lhm_{_migrationDateTimeStamp}] ON [{_origin.Name}] 
                         AFTER DELETE 
                         AS 
                         BEGIN

--- a/src/lhm.net/Invoker.cs
+++ b/src/lhm.net/Invoker.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using System.CodeDom.Compiler;
 using lhm.net.Logging;
 using lhm.net.Throttler;
+using Microsoft.SqlServer.Management.Common;
 
 namespace lhm.net
 {
@@ -16,14 +17,14 @@ namespace lhm.net
 
         private readonly Table _origin;
         private readonly ILhmConnection _connection;
-        private readonly string _dateTimeStamp;
+        private readonly MigrationDateTimeStamp _migrationDateTimeStamp;
 
         public Invoker(Table origin, ILhmConnection connection)
         {
             _origin = origin;
             _connection = connection;
-            _dateTimeStamp = DateTime.UtcNow.ToString(Constants.DateTimeStampFormat);
-            Migrator = new Migrator(_origin, _connection);
+            _migrationDateTimeStamp = new MigrationDateTimeStamp();
+            Migrator = new Migrator(_origin, _connection, _migrationDateTimeStamp);
         }
 
         public Migrator Migrator { get; }
@@ -34,7 +35,7 @@ namespace lhm.net
 
             options = ConfigureOptions(options);
 
-            var travelAgent = new Targeter(_origin, _connection, _dateTimeStamp);
+            var travelAgent = new Targeter(_origin, _connection, _migrationDateTimeStamp);
             travelAgent.Run();
             
             var migration = Migrator.Run();

--- a/src/lhm.net/MigrationDateTimeStamp.cs
+++ b/src/lhm.net/MigrationDateTimeStamp.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace lhm.net
+{
+    public class MigrationDateTimeStamp
+    {
+        private static readonly string EndsWithDatetimeStampPattern = $"{DatetimeStampPattern}$";
+        private const string DatetimeStampPattern = @"\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}_\d{3}";
+        private const string DateTimeStampFormat = "yyyy_MM_dd_HH_mm_ss_fff";
+
+        private readonly string _migrationDateTime;
+
+        /// <summary>
+        /// Create a migration dateTime stamp if no stamp value is provided one is generated from the current UTC dateTime
+        /// </summary>
+        /// <param name="migrationDateTime"></param>
+        public MigrationDateTimeStamp(string migrationDateTime = null)
+        {
+            if (migrationDateTime != null && !IsValid(migrationDateTime))
+                throw new ArgumentException("Invalid value", nameof(migrationDateTime));
+
+            _migrationDateTime = migrationDateTime ?? DateTime.UtcNow.ToString(DateTimeStampFormat);
+        }
+
+        /// <summary>
+        /// Add a migration datetime stamp to the end of a string in this format '{candidate}_{valueToStamp}.  If the value already end in a migration datetime stamp 
+        /// then replace that value with the new one provided
+        /// </summary>
+        public string Stamp(string candidate)
+        {
+            return EndWithMigrationDateTime(candidate) ? 
+                Regex.Replace(candidate, DatetimeStampPattern, _migrationDateTime) :
+                $"{candidate}_{_migrationDateTime}";
+        }
+
+        /// <summary>
+        /// Determines if a string contains a migration format datetime stamp
+        /// </summary>
+        public static bool ContainsMigrationDateTime(string candidate)
+        {
+            var match = Regex.Match(candidate, DatetimeStampPattern);
+            return match.Success;
+        }
+
+        public static bool IsValid(string candidate)
+        {
+            if (string.IsNullOrEmpty(candidate))
+                return false;
+
+            DateTime temp;
+            return DateTime.TryParseExact(candidate, DateTimeStampFormat, CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out temp);
+        }
+
+        public static bool TryParse(string candidate, out MigrationDateTimeStamp migrationDateTimeStamp)
+        {
+            migrationDateTimeStamp = null;
+            if (string.IsNullOrWhiteSpace(candidate))
+                return false;
+
+            if (IsValid(candidate))
+            {
+                migrationDateTimeStamp = new MigrationDateTimeStamp(candidate);
+                return true;
+            }
+            return false;
+        }
+
+        public static implicit operator string (MigrationDateTimeStamp migrationDateTimeStamp)
+        {
+            return migrationDateTimeStamp._migrationDateTime;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            return obj.ToString() == _migrationDateTime;
+        }
+
+        public override int GetHashCode()
+        {
+            return _migrationDateTime.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return _migrationDateTime;
+        }
+
+        private bool EndWithMigrationDateTime(string candidate)
+        {
+            var match = Regex.Match(candidate, EndsWithDatetimeStampPattern);
+            return match.Success;
+        }
+    }
+}

--- a/src/lhm.net/Migrator.cs
+++ b/src/lhm.net/Migrator.cs
@@ -16,15 +16,15 @@ namespace lhm.net
         private readonly ILhmConnection _connection;
         private readonly List<string> _statements;
         private readonly List<RenameMap> _renameMaps;
-        private readonly string _dateTimeStamp;
+        private readonly MigrationDateTimeStamp _migrationDateTimeStamp;
 
-        public Migrator(Table origin, ILhmConnection connection = null, string dateTimeStamp = null)
+        public Migrator(Table origin, ILhmConnection connection = null, MigrationDateTimeStamp migrationDateTimeStamp = null)
         {
             _origin = origin;
             _connection = connection;
             _statements = new List<string>();
             _renameMaps = new List<RenameMap>();
-            _dateTimeStamp = dateTimeStamp ?? DateTime.UtcNow.ToString(Constants.DateTimeStampFormat);
+            _migrationDateTimeStamp = migrationDateTimeStamp ?? new MigrationDateTimeStamp();
         }
 
         public string Source => _origin.Name;
@@ -91,7 +91,7 @@ namespace lhm.net
                 transaction.Commit();
             }
 
-            return new TableMigration(_origin, ReadDestination(), _dateTimeStamp, _renameMaps);
+            return new TableMigration(_origin, ReadDestination(), _migrationDateTimeStamp, _renameMaps);
         }
 
         private Table ReadDestination()

--- a/src/lhm.net/TableMigration.cs
+++ b/src/lhm.net/TableMigration.cs
@@ -5,11 +5,11 @@ namespace lhm.net
 {
     public class TableMigration
     {
-        public TableMigration(Table origin, Table destination, string dateTimeStamp = null, IEnumerable<RenameMap> renameMappings = null)
+        public TableMigration(Table origin, Table destination, MigrationDateTimeStamp migrationDateTimeStamp = null, IEnumerable<RenameMap> renameMappings = null)
         {
             Origin = origin;
             Destination = destination;
-            DateTimeStamp = dateTimeStamp ?? DateTime.UtcNow.ToString(Constants.DateTimeStampFormat);
+            MigrationDateTimeStamp = migrationDateTimeStamp ?? new MigrationDateTimeStamp();
             Intersection = new Intersection(Origin, Destination, renameMappings);
         }
 
@@ -17,9 +17,9 @@ namespace lhm.net
 
         public Table Destination { get; }
 
-        public string ArchiveName => $"lhm_{DateTimeStamp}_{Origin.Name}".Truncate(128);
+        public string ArchiveName => $"lhm_{MigrationDateTimeStamp}_{Origin.Name}".Truncate(128);
 
-        public string DateTimeStamp { get; }
+        public MigrationDateTimeStamp MigrationDateTimeStamp { get; }
 
         public Intersection Intersection { get; }
     }

--- a/src/lhm.net/Targeter.cs
+++ b/src/lhm.net/Targeter.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Globalization;
 using System.Text.RegularExpressions;
 using lhm.net.Logging;
 
@@ -13,14 +11,14 @@ namespace lhm.net
         private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly Table _origin;
         private readonly ILhmConnection _connection;
-        private readonly string _dateTimeStamp;
+        private readonly MigrationDateTimeStamp _migrationDateTimeStamp;
         private string _buildScript;
 
-        public Targeter(Table origin, ILhmConnection connection, string dateTimeStamp)
+        public Targeter(Table origin, ILhmConnection connection, MigrationDateTimeStamp migrationDateTimeStamp)
         {
             _origin = origin;
             _connection = connection;
-            _dateTimeStamp = dateTimeStamp;
+            _migrationDateTimeStamp = migrationDateTimeStamp;
             _buildScript = origin.Ddl;
         }
 
@@ -115,24 +113,7 @@ namespace lhm.net
 
         private string CreateTimeStampedKey(string primaryKey)
         {
-            var timeStampedKey = IsKeyAlreadyTimeStamped(primaryKey) ?
-                primaryKey.Remove(primaryKey.Length - Constants.DateTimeStampFormat.Length) + _dateTimeStamp :
-                $"{primaryKey}_{_dateTimeStamp}";
-            return timeStampedKey;
-        }
-
-        private static bool IsKeyAlreadyTimeStamped(string primaryKey)
-        {
-            if (primaryKey.Length < Constants.DateTimeStampFormat.Length)
-            {
-                return false;
-            }
-
-            var dateTimeStamp = primaryKey.GetLast(Constants.DateTimeStampFormat.Length);
-
-            DateTime temp;
-            var provider = CultureInfo.InvariantCulture;
-            return DateTime.TryParseExact(dateTimeStamp, Constants.DateTimeStampFormat, provider, DateTimeStyles.None, out temp);
+            return _migrationDateTimeStamp.Stamp(primaryKey);
         }
     }
 }

--- a/src/lhm.net/lhm.net.csproj
+++ b/src/lhm.net/lhm.net.csproj
@@ -57,13 +57,13 @@
     <Compile Include="AtomicSwitcher.cs" />
     <Compile Include="Chunker.cs" />
     <Compile Include="ColumnInfo.cs" />
-    <Compile Include="Constants.cs" />
     <Compile Include="ColumnInfoMap.cs" />
     <Compile Include="FKeyInfo.cs" />
     <Compile Include="ILhmConnection.cs" />
     <Compile Include="IndexDef.cs" />
     <Compile Include="IndexOrder.cs" />
     <Compile Include="LhmConnection.cs" />
+    <Compile Include="MigrationDateTimeStamp.cs" />
     <Compile Include="RenameMap.cs" />
     <Compile Include="Entangler.cs" />
     <Compile Include="IndexInfo.cs" />

--- a/src/tests/lhm.net.tests.unit/MigrationDateTimeStampTests.cs
+++ b/src/tests/lhm.net.tests.unit/MigrationDateTimeStampTests.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using Should.Fluent;
+using Xunit;
+
+namespace lhm.net.tests.unit
+{
+    public class MigrationDateTimeStampTests
+    {
+        [Fact]
+        public void Should_not_require_value_at_construction()
+        {
+            var sut = new MigrationDateTimeStamp();
+
+            sut.ToString()
+                .Should()
+                .Not
+                .Be
+                .Empty();
+        }
+
+        [Fact]
+        public void Should_throw_exception_if_constructed_with_invalid_arguments()
+        {
+            Assert.Throws<ArgumentException>(() => new MigrationDateTimeStamp("Foo"));
+        }
+
+        [Fact]
+        public void Should_construct_with_valid_value() => new MigrationDateTimeStamp(Valid.Samples.ValidMigrationDateTimeStamp);
+
+        public class TryParse
+        {
+            [Theory]
+            [InlineData(Valid.Samples.ValidMigrationDateTimeStamp, true)]
+            [InlineData(Invalid.Samples.InvalidYearFormat, false)]
+            [InlineData(Invalid.Samples.SingleDigitMonthFormat, false)] 
+            [InlineData(Invalid.Samples.SingleDigetDayFormat, false)] 
+            [InlineData(Invalid.Samples.SingleDigitHourFormat, false)] 
+            [InlineData(Invalid.Samples.SingleDigitMinutes, false)] 
+            [InlineData(Invalid.Samples.SingleDigitSeconds, false)] 
+            [InlineData(Invalid.Samples.IncorrectNumberOfMiliseconds, false)] 
+            [InlineData(Invalid.Samples.JustPlainRubbish, false)]
+            [InlineData(Invalid.Samples.InvalidMonth, false)]
+            [InlineData(Invalid.Samples.InvalidDays, false)]
+            [InlineData(Invalid.Samples.InvalidHours, false)]
+            [InlineData(Invalid.Samples.InvalidMinutes, false)]
+            [InlineData(Invalid.Samples.InvalidSeconds, false)]
+            public void Should_be_true_for_valid_value(string candidate, bool isValid)
+            {
+                MigrationDateTimeStamp temp;
+                var actual = MigrationDateTimeStamp.TryParse(candidate, out temp);
+
+                actual.Should().Equal(isValid);
+            }
+        }
+
+        public class IsValid
+        {
+            [Theory]
+            [InlineData(Valid.Samples.ValidMigrationDateTimeStamp, true)]
+            [InlineData(Invalid.Samples.InvalidYearFormat, false)]
+            [InlineData(Invalid.Samples.SingleDigitMonthFormat, false)]
+            [InlineData(Invalid.Samples.SingleDigetDayFormat, false)]
+            [InlineData(Invalid.Samples.SingleDigitHourFormat, false)]
+            [InlineData(Invalid.Samples.SingleDigitMinutes, false)]
+            [InlineData(Invalid.Samples.SingleDigitSeconds, false)]
+            [InlineData(Invalid.Samples.IncorrectNumberOfMiliseconds, false)]
+            [InlineData(Invalid.Samples.JustPlainRubbish, false)]
+            [InlineData(Invalid.Samples.InvalidMonth, false)]
+            [InlineData(Invalid.Samples.InvalidDays, false)]
+            [InlineData(Invalid.Samples.InvalidHours, false)]
+            [InlineData(Invalid.Samples.InvalidMinutes, false)]
+            [InlineData(Invalid.Samples.InvalidSeconds, false)]
+            public void Should_be_true_for_valid_value(string candidate, bool isValid)
+            {
+                var actual = MigrationDateTimeStamp.IsValid(candidate);
+
+                actual.Should().Equal(isValid);
+            }
+        }
+
+        public class Equality
+        {
+            [Fact]
+            public void Should_be_true_for_matching_stamps()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+
+                var one = new MigrationDateTimeStamp(stamp);
+                var two = new MigrationDateTimeStamp(stamp);
+
+                one.Equals(two).Should().Be.True();
+            }
+
+            [Fact]
+            public void Should_be_false_for_non_matching_stamps()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+
+                var one = new MigrationDateTimeStamp(stamp);
+                var two = new MigrationDateTimeStamp("2015_01_01_15_12_14_999");
+
+                one.Equals(two).Should().Be.False();
+            }
+
+            [Fact]
+            public void Should_be_false_null()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+
+                var one = new MigrationDateTimeStamp(stamp);
+
+                one.Equals(null).Should().Be.False();
+            }
+
+            [Fact]
+            public void Should_be_false_for_non_matching_string()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+
+                var one = new MigrationDateTimeStamp(stamp);
+
+                one.Equals("foo").Should().Be.False();
+            }
+
+            [Fact]
+            public void Should_be_true_for_matching_string()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+
+                var one = new MigrationDateTimeStamp(stamp);
+
+                one.Equals(stamp).Should().Be.True();
+            }
+        }
+
+        public class Stamp
+        {
+            [Fact]
+            public void Should_add_stamp_to_the_end_of_candidate_value()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+                var sut = new MigrationDateTimeStamp(stamp);
+
+                var actual = sut.Stamp("candidate");
+
+                var expected = $"candidate_{stamp}";
+
+                actual.Should().Equal(expected);
+            }
+
+            [Fact]
+            public void Should_swap_timestamp_candidate_value_already_end_one()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+                var sut = new MigrationDateTimeStamp(stamp);
+
+                var candidate = "candidate_2015_05_05_15_15_15_151";
+
+                var actual = sut.Stamp(candidate);
+                
+                actual.Should().Equal($"candidate_{stamp}");
+            }
+
+            [Fact]
+            public void Should_not_swap_timestamp_value_if_its_not_at_the_end_of_the_string()
+            {
+                var stamp = Valid.Samples.ValidMigrationDateTimeStamp;
+                var sut = new MigrationDateTimeStamp(stamp);
+
+                var candidate = "2015_05_05_15_15_15_151_candidate";
+
+                var actual = sut.Stamp(candidate);
+
+                actual.Should().Equal($"2015_05_05_15_15_15_151_candidate_{stamp}");
+            }
+        }
+
+        public class ContainsMigrationDateTime
+        {
+            [Theory]
+            [InlineData(Valid.Samples.ValidMigrationDateTimeStamp, true)]
+            [InlineData(Invalid.Samples.InvalidYearFormat, false)]
+            [InlineData(Invalid.Samples.SingleDigitMonthFormat, false)]
+            [InlineData("foo2015_05_05_15_15_15_151bar", true)]
+            [InlineData("2015_05_05_15_15_15_151bar", true)]
+            [InlineData("foo2015_05_05_15_15_15_151", true)]
+            [InlineData("foo2015_05_05_15_15_151", false)]
+            [InlineData("foo2015_05_05_15_15_151bar", false)]
+            public void Should_add_stamp_to_the_end_of_candidate_value(string candidate, bool isValid)
+            {
+                var actual = MigrationDateTimeStamp.ContainsMigrationDateTime(candidate);
+                
+                actual.Should().Equal(isValid);
+            }
+        }
+
+        private static class Invalid
+        {
+            public static class Samples
+            {
+                public const string InvalidYearFormat = "1_01_01_15_12_14_876";
+                public const string SingleDigitMonthFormat = "2015_1_01_15_12_14_876";
+                public const string SingleDigetDayFormat = "2015_01_1_15_12_14_876";
+                public const string SingleDigitHourFormat = "2015_01_01_7_12_14_876";
+                public const string SingleDigitMinutes = "2015_01_01_15_1_6_876";
+                public const string SingleDigitSeconds = "2015_01_01_15_12_4_876";
+                public const string IncorrectNumberOfMiliseconds = "2015_01_01_15_12_14_8";
+                public const string InvalidMonth = "2015_13_01_15_12_14_876";
+                public const string InvalidDays = "2015_13_32_15_12_14_876";
+                public const string InvalidHours = "2015_13_32_25_12_14_876";
+                public const string InvalidMinutes = "2015_13_32_25_61_14_876";
+                public const string InvalidSeconds = "2015_13_32_25_12_61_876";
+                public const string JustPlainRubbish = "Rubbish";
+            }
+        }
+
+        private static class Valid
+        {
+            public static class Samples
+            {
+                public const string ValidMigrationDateTimeStamp = "2015_01_01_15_12_14_876";
+            }
+        }
+
+    }
+}

--- a/src/tests/lhm.net.tests.unit/MigrationTests.cs
+++ b/src/tests/lhm.net.tests.unit/MigrationTests.cs
@@ -20,16 +20,17 @@ namespace lhm.net.tests.unit
         [Fact]
         public void Should_name_the_archive_with_provided_timeStamp()
         {
-            var sut = new TableMigration(new Table("Origin"), new Table("Destination"), "stamp");
+            var migrationDateTime = "2015_01_01_15_12_14_876";
+            var sut = new TableMigration(new Table("Origin"), new Table("Destination"), new MigrationDateTimeStamp(migrationDateTime));
 
             sut.ArchiveName.Should()
-                .Contain("lhm_stamp_Origin");
+                .Contain($"lhm_{migrationDateTime}_Origin");
         }
 
         [Fact]
         public void Should_limit_the_name_to_128_characters()
         {
-            var sut = new TableMigration(new Table("a_very_very_very_very_very_very_very_very_very_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_128_chars"), new Table("lhm_Foo"), "stamp");
+            var sut = new TableMigration(new Table("a_very_very_very_very_very_very_very_very_very_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_128_chars"), new Table("lhm_Foo"));
 
             sut.ArchiveName.Length.Should().Equal(128);
         }

--- a/src/tests/lhm.net.tests.unit/lhm.net.tests.unit.csproj
+++ b/src/tests/lhm.net.tests.unit/lhm.net.tests.unit.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="ChunkerTests.cs" />
     <Compile Include="IntersectionTests.cs" />
+    <Compile Include="MigrationDateTimeStampTests.cs" />
     <Compile Include="MigrationTests.cs" />
     <Compile Include="MigratorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
resolves #60 

I'm not sure if this is overkill @Amila17 what do you think.  I think its clean but it may be going a bit far. 

Added MigrationDateTimeStamp to hold and manage all logic related to the
migration datetime stamp to avoid this spilling into other classes.

This class allows you to pass around a typed object that will validate
stamps. Stamp values and you can test stamp equality.

Added full test coverage.  
